### PR TITLE
System priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ entityManager.removeSystem(movementSystem);
 
 You may want to run systems in a given order, or prioritise some systems over others.
 
-You can enable this behaviour when overriding the `System` constructor. Systems have a priority of 0 by default. This means that when not specified, systems have the lowest possible priority, and are executed in the order they're added to the manager.
+You can enable this behaviour when overriding the `EntitySystem` constructor. Systems have a priority of 0 by default. This means that when not specified, systems have the lowest possible priority, and are executed in the order they're added to the manager.
 
 Interact with this how you choose. But, for example, if you want to mimic the default constructor, and take a dynamic priority parameter:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Stuj is an Entity Component System framework written in Java. It aims to provide
 * [Component](#component)
     + [Adding and Removing Components](#adding-and-removing-components)
 * [EntitySystem](#entitysystem)
+    + [System Priority](#system-priority)
     + [IteratorSystem](#iteratorsystem)
 * [EntityListener](#entitylistener)
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,30 @@ Systems can also be removed dynamically:
 entityManager.removeSystem(movementSystem);
 ```
 
+### System Priority
+
+You may want to run systems in a given order, or prioritise some systems over others.
+
+You can enable this behaviour when overriding the `System` constructor. Systems have a priority of 0 by default. This means that when not specified, systems have the lowest possible priority, and are executed in the order they're added to the manager.
+
+Interact with this how you choose. But, for example, if you want to mimic the default constructor, and take a dynamic priority parameter:
+
+```java
+public class MovementSystem extends EntitySystem {
+    HashMap<Entity, Component> positionComponentMap;
+    HashMap<Entity, Component> velocityComponentMap;
+
+    public MovementSystem (EntityManager entityManager, int priority) {
+        super(priority);
+        // ...
+    }
+}
+```
+
+You can then instantiate your system with a given priority, `MovementSystem movementSystem = new MovementSystem(1)`
+
+Systems with a higher priority will be executed first by the `EntityManager`.
+
 ### IteratorSystem
 
 Most systems will involve iterating over a `Family`. To avoid redundant code, stup-ecs provides a handy utility class which will do this for you, called `IteratorSystem`.

--- a/stuj/src/com/github/jaynewey/stuj/EntityManager.java
+++ b/stuj/src/com/github/jaynewey/stuj/EntityManager.java
@@ -104,6 +104,8 @@ public class EntityManager {
      */
     public void addSystem(EntitySystem system) {
         systems.add(system);
+        systems.sort(Comparator.comparingInt(EntitySystem::getPriority).reversed());
+        System.out.println(systems);
     }
 
     /**

--- a/stuj/src/com/github/jaynewey/stuj/EntitySystem.java
+++ b/stuj/src/com/github/jaynewey/stuj/EntitySystem.java
@@ -1,10 +1,23 @@
 package com.github.jaynewey.stuj;
 
+import java.util.function.ToIntFunction;
+
 /**
  * Abstract class for processing Entity instances.
  */
 public abstract class EntitySystem {
     public Family family;
+    private int priority = 0;
+
+    public EntitySystem() {}
+
+    public EntitySystem(int priority) {
+        this.priority = priority;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
 
     /**
      * The update method that is called every tick.


### PR DESCRIPTION
Allows users to specify a priority for `EntityManager` to respect when executing `update()`.

Resolves #3 